### PR TITLE
Fix view authentication when logged in

### DIFF
--- a/logiclearner/main/views.py
+++ b/logiclearner/main/views.py
@@ -8,6 +8,7 @@ from logiclearner.main.serializers import (
 )
 from rest_framework import generics
 from rest_framework.response import Response
+from rest_framework.permissions import AllowAny
 from django.http.response import Http404
 from django.shortcuts import render, get_object_or_404
 from logictools.next_step import next_step
@@ -21,10 +22,9 @@ def handler404(request):
     return render(request, '404.html')
 
 
+@method_decorator(csrf_exempt, name='dispatch')
 class HintApiView(APIView):
-    @method_decorator(csrf_exempt)
-    def dispatch(self, *args, **kwargs):
-        return super(HintApiView, self).dispatch(*args, **kwargs)
+    authentication_classes = []
 
     def post(self, request):
         next_expr = request.data.get('next_expr', None)

--- a/logiclearner/main/views.py
+++ b/logiclearner/main/views.py
@@ -8,7 +8,6 @@ from logiclearner.main.serializers import (
 )
 from rest_framework import generics
 from rest_framework.response import Response
-from rest_framework.permissions import AllowAny
 from django.http.response import Http404
 from django.shortcuts import render, get_object_or_404
 from logictools.next_step import next_step

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "babel-loader": "^8.2.2",
     "bootstrap": "^5.1.1",
-    "react": "^17.0.2",",
+    "react": "^18.1.0",
     "react-dom": "^18.1.0",
     "react-ga": "^3.3.1",
     "react-router-dom": "^6.0.2",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "babel-loader": "^8.2.2",
     "bootstrap": "^5.1.1",
-    "react": "^18.1.0",
+    "react": "^17.0.2",",
     "react-dom": "^18.1.0",
     "react-ga": "^3.3.0",
     "react-router-dom": "^6.0.2",


### PR DESCRIPTION
By default, django-restframework views require csrf tokens when using session-level authentication. This PR removes session-level authentication for the HintsView.