### PR TITLE
Revert "Bump django-compressor from 4.0 to 4.1"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -59,7 +59,7 @@ django-annoying==0.10.6
 django-appconf==1.0.5
 rcssmin==1.1.0  # django-compressor
 rjsmin==1.2.0  # django-compressor
-django-compressor==4.1
+django-compressor==4.0
 django-statsd-mozilla==0.4.0
 raven==6.10.0  # Remove from ccnmtlsettings, then here.
 sentry-sdk==1.9.0


### PR DESCRIPTION
Reverts ccnmtl/logiclearner#527