### PR TITLE
:arrow_up: torch 2.0.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -117,7 +117,13 @@ requirements/src/django_cas_ng-4.2.2ctl-py2.py3-none-any.whl
 # logictools
 lark==1.1.2
 logiclearnertools==0.1.9
-torch==1.12.1
+
+mpmath==1.3.0  # sympy
+sympy==1.12  # torch
+
+--extra-index-url https://download.pytorch.org/whl/cpu
+torch==2.0.1
+
 numpy<1.26
 levenshtein==0.21.0
 rapidfuzz==3.2.0


### PR DESCRIPTION
Torch version >=1.13.0 is required for python 3.11, and these new versions of torch use Nvidia CUDA by default, which requires special libraries to be installed. I don't think we need this, and the recommended way to install torch without CUDA is with a separate index-url in pip, as described here:
  https://pytorch.org/get-started/locally/#no-cuda