### PR TITLE
Upgrade to Django 4.2

### DIFF
--- a/logiclearner/main/management/commands/integrationserver.py
+++ b/logiclearner/main/management/commands/integrationserver.py
@@ -22,7 +22,7 @@ from logiclearner.factories import LogicLearnerTestMixin
 class Command(BaseCommand):
     help = 'Runs a development server with data created by factories.'
 
-    requires_system_checks = False
+    requires_system_checks = []
 
     def add_arguments(self, parser):
         parser.add_argument(

--- a/logiclearner/main/tests/test_views.py
+++ b/logiclearner/main/tests/test_views.py
@@ -5,11 +5,11 @@ from logiclearner.main.tests.factories import SolutionFactory, StatementFactory
 class BasicTest(TestCase):
     def test_root(self):
         response = self.client.get("/")
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
 
     def test_smoketest(self):
         response = self.client.get("/smoketest/")
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'PASS')
 
 

--- a/logiclearner/settings_shared.py
+++ b/logiclearner/settings_shared.py
@@ -15,7 +15,6 @@ PROJECT_APPS = [
 USE_TZ = True
 
 INSTALLED_APPS += [  # noqa
-    'infranil',
     'django_extensions',
     'rest_framework',
     'logiclearner.main',

--- a/logiclearner/urls.py
+++ b/logiclearner/urls.py
@@ -23,7 +23,6 @@ urlpatterns = [
          name='cas_ng_logout'),
     path('stats/', TemplateView.as_view(template_name="stats.html")),
     path('smoketest/', include('smoketest.urls')),
-    path('infranil/', include('infranil.urls')),
     path('uploads/<str:path>',
          serve, {'document_root': settings.MEDIA_ROOT}),
     path('robots.txt', TemplateView.as_view(template_name="robots.txt",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-Django>=3.2.14,<4
+Django==4.2.11
 pytz==2024.1
 httplib2==0.22.0
 feedparser==6.0.8
-Markdown==3.5 # pyup: < 3
+Markdown==3.5.2 # pyup: < 3
 psycopg2==2.9.3
 versiontools==1.9.1
 statsd==4.0.1
@@ -66,11 +66,10 @@ django-debug-toolbar==4.3.0
 django-smoketest==1.2.0
 # For django-extensions
 typing==3.7.4.1; python_version < '3.5'
-django-extensions==3.2.0
+django-extensions==3.2.1
 django-stagingcontext==0.1.0
 django-ga-context==0.1.0
 django-impersonate==1.9.1
-django-markwhat==1.6.2
 gunicorn==21.2.0
 django-infranil==1.1.0
 django-flatblocks==1.0.0
@@ -92,7 +91,7 @@ pyparsing==3.1.0
 edtf==4.0.1 # pyup: <4.0.0
 
 pbr==6.0.0 # bandit
-pyyaml==6.0 # bandit
+pyyaml==6.0.1 # bandit
 stevedore==5.2.0  # bandit
 bandit==1.7.0
 
@@ -114,8 +113,14 @@ mpmath==1.3.0  # sympy
 sympy==1.12  # torch
 
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch==2.1.0
+torch==2.2.1
 
 numpy<1.27
 levenshtein==0.25.0
 rapidfuzz==3.6.0
+
+backports.zoneinfo==0.2.1; python_version < '3.9'
+webencodings==0.5.1 # django-markdownify
+tinycss2==1.2.1 # django-markdownify
+bleach==6.0.0 # django-markdownify
+django-markdownify==0.9.3


### PR DESCRIPTION
`psycopg3` was having trouble with related dependencies so I rolled it back to see if there were any compatibility issues. It seems to be running fine on my end, so I'm going to leave it as `psycopg2` for now.