### PR TITLE
Downgrade astroid to 3.2.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,7 @@ certifi==2024.8.30  # requests, sentry-sdk
 requests==2.32.1
 typing_extensions==4.12.0
 
-astroid==3.3.2
+astroid==3.2.4
 pylint==3.2.0
 
 six==1.16.0


### PR DESCRIPTION
This newer version dropped python 3.8 support, and this application is not quite fully migrated off of python 3.8 yet.