### PR TITLE
Add python 3.8 testing again

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-          python-version: ["3.12"]
+          python-version: ["3.8", "3.12"]
           node-version: [20.x]
     name: Node ${{ matrix.node }} run
     steps:

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,7 @@ certifi==2024.8.30  # requests, sentry-sdk
 requests==2.32.1
 typing_extensions==4.12.0
 
-astroid==3.3.2
+astroid==3.2.4
 pylint==3.2.0
 
 six==1.16.0


### PR DESCRIPTION
This application isn't fully migrated to the new django yet, and the old version of python requires this older version of astroid.